### PR TITLE
feat: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Issue (e.g. Issue [RSS-ECOMM-1_01](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint1/RSS-ECOMM-1_01.md): Set up GitHub repository)
+
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Changes Made
+
+Describe the specific changes that have been made in this pull 
+request. Provide details on the approach taken to address the problem 
+and any notable implementation details.
+
+## Checklist
+
+- [ ] I have added comments to code in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
# Issue [RSS-ECOMM-1_21](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint1/RSS-ECOMM-1_21.md)

## Description

A file with a template for pull requests has been created. Now team members can rely on this template when writing pull requests

## Changes Made

A file called `pull_request_tempalte.md` has been created in the `.github` directory, which contains a template for future pull requests

## Checklist

- [x] A pull request template file is created and saved to the repository
- [x] The template has a clear structure for describing proposed changes
- [x] The template includes sections for providing the rationale behind the changes